### PR TITLE
Verilator

### DIFF
--- a/configure
+++ b/configure
@@ -19,6 +19,14 @@ cat << EOF > ${THISDIR}/Makefile
 #all: chisel sim
 all: sim
 
+verilator:
+	rm -rf ${THISDIR}/sv/obj_dir/foobadir
+	rm -f ${THISDIR}/sv/obj_dir/*
+	mkdir ${THISDIR}/sv/obj_dir/foobadir
+	cd ${THISDIR}/sv && verilator -Wall --cc --exe --build --trace ./sim_main.cpp ./inverter.sv
+	cd ${THISDIR}/sv/obj_dir/ && ./Vinverter && cd ../..
+
+
 #sim: chisel
 sim:
 	cd ${THISDIR}/${MODULE} && \\

--- a/sv/inverter.sv
+++ b/sv/inverter.sv
@@ -1,3 +1,4 @@
+//verilator lint_off UNUSED
 module inverter( input reset,
                  input A, 
                  output Z );
@@ -5,3 +6,4 @@ module inverter( input reset,
 assign Z= !A;
 
 endmodule
+//verilator lint_on UNUSED

--- a/sv/sim_main.cpp
+++ b/sv/sim_main.cpp
@@ -14,7 +14,6 @@ int main(int argc, char** argv, char** env) {
     tfp->open("foobadir/simx.vcd");
     static bool reset = 0;
     static bool clock = 0;
-    static bool A = 0;
     static int count = 0;
     //while (!Verilated::gotFinish()) { 
     std::cout << "Starting the sucker!" << std::endl; 
@@ -25,7 +24,7 @@ int main(int argc, char** argv, char** env) {
 		top->eval(); 
         tfp->dump(contextp->time());
         //usleep(10000);
-        VL_PRINTF("fooba %d\n",top->Z);
+        VL_PRINTF("A is %d , Z is %d\n",top->A, top->Z);
             //top->clk, top->reset_l, top->in_quad, top->out_quad,
             //      top->out_wide[2], top->out_wide[1], top->out_wide[0]);
         //std::cout << contextp->time() << std::endl;

--- a/sv/sim_main.cpp
+++ b/sv/sim_main.cpp
@@ -6,7 +6,9 @@
 int main(int argc, char** argv, char** env) {
     VerilatedContext* contextp = new VerilatedContext;
     contextp->commandArgs(argc, argv);
+    /* verilator lint_off UNUSED */
     Vinverter* top = new Vinverter(contextp);
+    /* verilator lint_on UNUSED */
     Verilated::internalsDump();
     Verilated::traceEverOn(true);
     VerilatedVcdC* tfp = new VerilatedVcdC;
@@ -19,7 +21,6 @@ int main(int argc, char** argv, char** env) {
     std::cout << "Starting the sucker!" << std::endl; 
     while (contextp->time() < 1000) { 
 		clock = !clock;
-		top->reset = 0;
 		top->A = clock;
 		top->eval(); 
         tfp->dump(contextp->time());

--- a/sv/sim_main.cpp
+++ b/sv/sim_main.cpp
@@ -1,0 +1,39 @@
+#include "Vinverter.h"
+#include <iostream>             // Need std::cout
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+
+int main(int argc, char** argv, char** env) {
+    VerilatedContext* contextp = new VerilatedContext;
+    contextp->commandArgs(argc, argv);
+    Vinverter* top = new Vinverter(contextp);
+    Verilated::internalsDump();
+    Verilated::traceEverOn(true);
+    VerilatedVcdC* tfp = new VerilatedVcdC;
+    top->trace(tfp, 99);  // Trace 99 levels of hierarchy
+    tfp->open("foobadir/simx.vcd");
+    static bool reset = 0;
+    static bool clock = 0;
+    static bool A = 0;
+    static int count = 0;
+    //while (!Verilated::gotFinish()) { 
+    std::cout << "Starting the sucker!" << std::endl; 
+    while (contextp->time() < 1000) { 
+		clock = !clock;
+		top->reset = 0;
+		top->A = clock;
+		top->eval(); 
+        tfp->dump(contextp->time());
+        //usleep(10000);
+        VL_PRINTF("fooba %d\n",top->Z);
+            //top->clk, top->reset_l, top->in_quad, top->out_quad,
+            //      top->out_wide[2], top->out_wide[1], top->out_wide[0]);
+        //std::cout << contextp->time() << std::endl;
+        contextp->timeInc(1);
+	}
+    top->final();
+    delete top;
+    delete contextp;
+    exit(0);
+}
+

--- a/sv/sim_main.cpp
+++ b/sv/sim_main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char** argv, char** env) {
         contextp->timeInc(1);
 	}
     top->final();
+    tfp->close();
     delete top;
     delete contextp;
     exit(0);

--- a/sv/verilator_commands
+++ b/sv/verilator_commands
@@ -1,3 +1,4 @@
-verilator -Wall --cc --exe --build --trace sim_main.cpp inverter.sv
-cd obj_dir/ && ./Vinverter
+rm -f ./obj_dir/*
+verilator -Wall --cc --exe --build --trace ./sim_main.cpp ./inverter.sv
+cd obj_dir/ && ./Vinverter && cd ..
 

--- a/sv/verilator_commands
+++ b/sv/verilator_commands
@@ -1,4 +1,0 @@
-rm -f ./obj_dir/*
-verilator -Wall --cc --exe --build --trace ./sim_main.cpp ./inverter.sv
-cd obj_dir/ && ./Vinverter && cd ..
-

--- a/sv/verilator_commands
+++ b/sv/verilator_commands
@@ -1,0 +1,3 @@
+verilator -Wall --cc --exe --build --trace sim_main.cpp inverter.sv
+cd obj_dir/ && ./Vinverter
+


### PR DESCRIPTION
@Roenski I do not know how much you have worked on this already, but this branch contains a minimum working example of inverter simulation with verilator. It is

Currently simulation is not executed from python, but by by executing `./configure && make verilator` . configure is the documentation of the command calls.

The testbench file sim_main.cpp contains the minimum set of additional variable definitions, verilator function calls, and vcd dump.

Objectives.

1.  Transfer the simulator calls to rtl package
2.  Implement the testbench generation in rtl/testbench package.

Eventually these two branches will be merged to RC_1.9 development branch in a state were the verilog simulation with verilator can be run as a standard TheSyDeKick simulation, including interactive mode.